### PR TITLE
.vscode: debug: Change debug to attach to a prelaunched west debugserver

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,27 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch",
-            "device": "nRF52840_xxAA",
-            "cwd": "${workspaceFolder}",
-            "executable": "build/zephyr/zephyr.elf",
-            "request": "launch",
-            "type": "cortex-debug",
-            "runToEntryPoint": "main",
-            "servertype": "jlink",
-            "gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
-            "preLaunchTask": "West Build"
-        },
-        {
-            "name": "Attach",
-            "device": "nRF52840_xxAA",
+            "name": "Launch and Attach to GDB Server",
             "cwd": "${workspaceFolder}",
             "executable": "build/zephyr/zephyr.elf",
             "request": "attach",
             "type": "cortex-debug",
             "runToEntryPoint": "main",
-            "servertype": "jlink",
-            "gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
+            "servertype": "external",
+            "gdbTarget": "127.0.0.1:3333",
+            "gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
+            "preLaunchTask": "Start West Debug Server",
+            "postDebugTask": "Stop West Debug Server"
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,6 +72,40 @@
 			"problemMatcher": [
 				"$gcc"
 			]
+		},
+		{
+			"label": "Start West Debug Server",
+			"type": "shell",
+			"isBackground": true,
+			"command": "west debugserver",
+			"dependsOn": "West Build",
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": true,
+				"clear": false
+			},
+			"problemMatcher": [
+                {
+                    "pattern": [{
+                    "regexp": ".",
+                    "file": 1,"line": 1,
+                    "column": 1,"message": 1
+                    }],
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": { "regexp": "." },
+                        "endsPattern": { "regexp": "." }
+                    },
+                }
+            ]
+		},
+		{
+			"label": "Stop West Debug Server",
+			"command": "echo ${input:terminate west debug server}",
+            "type": "shell"
 		}
 	],
 	"inputs": [
@@ -91,6 +125,12 @@
 				"always",
 				"never"
 			]
+		},
+		{
+			"id": "terminate west debug server",
+			"type": "command",
+			"command": "workbench.action.tasks.terminate",
+			"args": "Start West Debug Server"
 		}
 	]
 }


### PR DESCRIPTION
Change debug paradigm to attach to a prelaunched `west debugserver `instance. `task.json `now have two new tasks: one run `debugserver `in silent mode in the terminal window, and one to close it. `launch.json `now call the debugserver window at start and then attach the debugger to it instead of launching the debugger directly. This unionize the debug calls to west debug only.