### PR TITLE
Update version number to latest version 0.16.8

### DIFF
--- a/zephyr-linux.code-workspace
+++ b/zephyr-linux.code-workspace
@@ -9,7 +9,7 @@
 		"cmake.configureOnOpen": false,
 
 		// IntelliSense
-		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
+		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
 		"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
 
 		// File Associations
@@ -99,7 +99,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
 				"preLaunchTask": "West Build"
 			},
 			{
@@ -111,7 +111,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
 			},
 		]
 	},

--- a/zephyr-macos.code-workspace
+++ b/zephyr-macos.code-workspace
@@ -9,7 +9,7 @@
 		"cmake.configureOnOpen": false,
 
 		// IntelliSense
-		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
+		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
 		"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
 
 		// File Associations
@@ -99,7 +99,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
 				"preLaunchTask": "West Build"
 			},
 			{
@@ -111,7 +111,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
 			},
 		]
 	},

--- a/zephyr-windows.code-workspace
+++ b/zephyr-windows.code-workspace
@@ -9,7 +9,7 @@
 		"cmake.configureOnOpen": false,
 
 		// IntelliSense
-		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
+		"C_Cpp.default.compilerPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc",
 		"C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
 
 		// File Associations
@@ -99,7 +99,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb",
 				"preLaunchTask": "West Build"
 			},
 			{
@@ -111,7 +111,7 @@
 				"type": "cortex-debug",
 				"runToEntryPoint": "main",
 				"servertype": "jlink",
-				"gdbPath": "${userHome}/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
+				"gdbPath": "${userHome}/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb"
 			},
 		]
 	},


### PR DESCRIPTION
**Summary:**
This pull request updates the Zephyr version mentioned in the repository from 0.16.1 to 0.16.8.

**Details:**
- The current documentation/code references Zephyr version 0.16.1, which is outdated.
- The latest stable version of Zephyr is 0.16.8. Updating this ensures that the project remains up-to-date with the latest improvements, features, and bug fixes.

**Reason for Update:**
Keeping the project aligned with the latest version helps in taking advantage of the latest enhancements in Zephyr.
This update also helps avoid potential compatibility issues with new tools or dependencies that expect the latest version.

Please review the changes and consider merging this update to keep the project updated.